### PR TITLE
Fix a crash in pypy.

### DIFF
--- a/trio/_core/_wakeup_socketpair.py
+++ b/trio/_core/_wakeup_socketpair.py
@@ -6,7 +6,7 @@ import warnings
 from .. import _core
 from .._util import is_main_thread
 
-if sys.version_info >= (3, 7):
+if sys.version_info >= (3, 7) and '__pypy__' not in sys.builtin_module_names:
     HAVE_WARN_ON_FULL_BUFFER = True
 else:
     HAVE_WARN_ON_FULL_BUFFER = False


### PR DESCRIPTION
Apparently, in pypy, "signal.set_wakeup_fd" doesn't have the keyword argument warn_on_full_buffer.

Here is a simple script to reproduce this problem:
```
import trio

async def handler(stream: trio.abc.Stream):
    await stream.receive_some(1)

async def trio_main():
    socket_listeners = await trio.serve_tcp(handler)

trio.run(trio_main)
```
The error message is:
```
Traceback (most recent call last):
  File "/home/leo/test/triotest/pypyvenv/site-packages/trio/_core/_run.py", line 2030, in unrolled_run
    runner.entry_queue.wakeup.wakeup_on_signals()
  File "/home/leo/test/triotest/pypyvenv/site-packages/trio/_core/_wakeup_socketpair.py", line 66, in wakeup_on_signals
    self.old_wakeup_fd = signal.set_wakeup_fd(fd, warn_on_full_buffer=False)
TypeError: set_wakeup_fd() got an unexpected keyword argument 'warn_on_full_buffer'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "t.py", line 9, in <module>
    trio.run(trio_main)
  File "/home/leo/test/triotest/pypyvenv/site-packages/trio/_core/_run.py", line 1919, in run
    timeout = gen.send(next_send)
  File "/home/leo/test/triotest/pypyvenv/site-packages/trio/_core/_run.py", line 2226, in unrolled_run
    raise TrioInternalError("internal error in Trio - please file a bug!") from exc
trio.TrioInternalError: internal error in Trio - please file a bug!

```

My environment is:
```
$ pypy3 --version
Python 3.7.4 (87875bf2dfd8, Sep 24 2020, 07:26:36)
[PyPy 7.3.2-alpha0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```
And 
```trio==0.17.0```